### PR TITLE
Trivial port to Py3, hello_world works. Still compatible with Py2

### DIFF
--- a/examples/disassemble.py
+++ b/examples/disassemble.py
@@ -8,7 +8,7 @@ from jawa import ClassFile
 from jawa.util.bytecode import OperandTypes
 
 if __name__ == '__main__':
-    with open(sys.argv[1]) as fin:
+    with open(sys.argv[1], 'rb') as fin:
         cf = ClassFile(fin)
 
         # The constant pool.

--- a/jawa/attributes/code.py
+++ b/jawa/attributes/code.py
@@ -15,7 +15,11 @@ from jawa.util.bytecode import (
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import BytesIO
+        StringIO = BytesIO
 
 
 CodeException = namedtuple('CodeException', [
@@ -114,4 +118,3 @@ class CodeAttribute(Attribute):
 
         for ins in iter(lambda: read_instruction(fio, fio.tell()), None):
             yield ins
-

--- a/jawa/cf.py
+++ b/jawa/cf.py
@@ -190,7 +190,8 @@ class ClassFile(object):
         return self._version
 
     @version.setter
-    def version(self, (major, minor)):
+    def version(self, major_minor):
+        major, minor = major_minor
         self._version = ClassVersion(major, minor)
 
     @property

--- a/jawa/constants.py
+++ b/jawa/constants.py
@@ -431,7 +431,7 @@ class ConstantPool(object):
                     constant.TAG,
                     length
                 ))
-                write(constant.value)
+                write(constant.value.encode('utf-8'))
             elif isinstance(constant, ConstantInteger):
                 write(pack('>Bi',
                     constant.TAG,

--- a/jawa/constants.py
+++ b/jawa/constants.py
@@ -56,7 +56,7 @@ class ConstantUTF8(Constant):
 
     def __init__(self, pool, index, value):
         super(ConstantUTF8, self).__init__(pool, index)
-        self.value = value
+        self.value = value.decode('utf-8')
 
     def __repr__(self):
         return 'ConstantUTF8(value={0!r})'.format(self.value)

--- a/jawa/constants.py
+++ b/jawa/constants.py
@@ -64,7 +64,10 @@ class ConstantUTF8(Constant):
     def __init__(self, pool, index, value):
         super(ConstantUTF8, self).__init__(pool, index)
         if not isinstance(value, unicode):
-            value = value.decode('utf-8')
+            try:
+                value = value.decode('utf-8')
+            except UnicodeDecodeError:
+                pass
         self.value = value
 
     def __repr__(self):
@@ -418,7 +421,12 @@ class ConstantPool(object):
             if tag == 1:
                 # CONSTANT_Utf8_info, a length prefixed UTF-8-ish string.
                 length = unpack('>H', read(2))[0]
-                self.append((tag, read(length).decode('utf-8')))
+                value = read(length)
+                try:
+                    value = value.decode('utf-8')
+                except UnicodeDecodeError:
+                    pass
+                self.append((tag, value))
             else:
                 # Every other constant type is trivial.
                 fmt, size = _constant_fmts[tag]

--- a/jawa/constants.py
+++ b/jawa/constants.py
@@ -16,6 +16,13 @@ __all__ = (
     'ConstantNameAndType'
 )
 
+try:
+	unicode
+	basestring
+except NameError:
+	unicode = str  # compatibility for Python 3
+	basestring = str  # compatibility for Python 3
+
 from struct import unpack, pack
 
 
@@ -56,7 +63,9 @@ class ConstantUTF8(Constant):
 
     def __init__(self, pool, index, value):
         super(ConstantUTF8, self).__init__(pool, index)
-        self.value = value.decode('utf-8')
+        if not isinstance(value, unicode):
+            value = value.decode('utf-8')
+        self.value = value
 
     def __repr__(self):
         return 'ConstantUTF8(value={0!r})'.format(self.value)
@@ -409,7 +418,7 @@ class ConstantPool(object):
             if tag == 1:
                 # CONSTANT_Utf8_info, a length prefixed UTF-8-ish string.
                 length = unpack('>H', read(2))[0]
-                self.append((tag, read(length)))
+                self.append((tag, read(length).decode('utf-8')))
             else:
                 # Every other constant type is trivial.
                 fmt, size = _constant_fmts[tag]

--- a/jawa/jf.py
+++ b/jawa/jf.py
@@ -14,7 +14,11 @@ __all__ = ('JarFile',)
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import BytesIO
+        StringIO = BytesIO
 
 from jawa.util.ezip import EditableZipFile
 from jawa.cf import ClassFile

--- a/jawa/util/ezip.py
+++ b/jawa/util/ezip.py
@@ -11,7 +11,11 @@ except ImportError:
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import BytesIO
+        StringIO = BytesIO
 
 
 class EditableZipFile(object):


### PR DESCRIPTION
This commit is 90% ImportExceptions and one trivial change to encoding strings. 
Hope to maintain Py2/Py3 compatibility moving forward

Might break other things, only tested hello_world