### PR TITLE
Py3 compatibility, maintains Py2 compatibility

### DIFF
--- a/examples/disassemble.py
+++ b/examples/disassemble.py
@@ -8,7 +8,7 @@ from jawa import ClassFile
 from jawa.util.bytecode import OperandTypes
 
 if __name__ == '__main__':
-    with open(sys.argv[1]) as fin:
+    with open(sys.argv[1], 'rb') as fin:
         cf = ClassFile(fin)
 
         # The constant pool.

--- a/jawa/attributes/code.py
+++ b/jawa/attributes/code.py
@@ -15,7 +15,10 @@ from jawa.util.bytecode import (
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import BytesIO as StringIO
 
 
 CodeException = namedtuple('CodeException', [
@@ -114,4 +117,3 @@ class CodeAttribute(Attribute):
 
         for ins in iter(lambda: read_instruction(fio, fio.tell()), None):
             yield ins
-

--- a/jawa/cf.py
+++ b/jawa/cf.py
@@ -190,8 +190,8 @@ class ClassFile(object):
         return self._version
 
     @version.setter
-    def version(self, (major, minor)):
-        self._version = ClassVersion(major, minor)
+    def version(self, major_minor):
+        self._version = ClassVersion(*major_minor)
 
     @property
     def constants(self):

--- a/jawa/constants.py
+++ b/jawa/constants.py
@@ -20,6 +20,10 @@ from struct import unpack, pack
 
 from jawa.util.utf import decode_modified_utf8, encode_modified_utf8
 
+try:
+    unicode
+except NameError:
+    unicode = str
 
 class Constant(object):
     """

--- a/jawa/jf.py
+++ b/jawa/jf.py
@@ -14,7 +14,11 @@ __all__ = ('JarFile',)
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import BytesIO as StringIO
+
 
 from jawa.util.ezip import EditableZipFile
 from jawa.cf import ClassFile

--- a/jawa/util/ezip.py
+++ b/jawa/util/ezip.py
@@ -11,7 +11,10 @@ except ImportError:
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import BytesIO as StringIO
 
 
 class EditableZipFile(object):

--- a/jawa/util/utf.py
+++ b/jawa/util/utf.py
@@ -8,6 +8,12 @@ when parsing and writing JVM ClassFiles or object serialization archives.
     for MUTF-8/CESU-8 into the python core.
 """
 
+try:
+    unicode
+    unichr
+except NameError:
+    unicode = str
+    unichr = chr
 
 def decode_modified_utf8(s):
     """
@@ -77,4 +83,4 @@ def encode_modified_utf8(u):
                 (0x80 | (0x3F & c))
             )
 
-    return str(final_string)
+    return final_string


### PR DESCRIPTION
This patch is a handful of import changes and unicode aliases necessary to run Jawa on Python 3.x . It maintains 100% compatibility with Python 2 and has no performance implications as far as I can tell.