### PR TITLE
Fix disassemble and doc example on Windows

### DIFF
--- a/examples/disassemble.py
+++ b/examples/disassemble.py
@@ -8,7 +8,7 @@ from jawa import ClassFile
 from jawa.util.bytecode import OperandTypes
 
 if __name__ == '__main__':
-    with open(sys.argv[1]) as fin:
+    with open(sys.argv[1], 'rb') as fin:
         cf = ClassFile(fin)
 
         # The constant pool.

--- a/jawa/cf.py
+++ b/jawa/cf.py
@@ -46,7 +46,7 @@ class ClassFile(object):
     To open an existing ClassFile::
 
         from jawa import ClassFile
-        with open('HelloWorld.class') as fin:
+        with open('HelloWorld.class', 'rb') as fin:
             cf = ClassFile(fin)
 
     To save a newly created or modified ClassFile::


### PR DESCRIPTION
Open defaults to `'r'`, which means that Windows' line endings would get converted, causing class files to get parsed incorrectly.  This changes to explicitly use `'rb'`, avoiding that problem.