### PR TITLE
Add support for the Signature attribute

### DIFF
--- a/jawa/attribute.py
+++ b/jawa/attribute.py
@@ -177,9 +177,11 @@ class AttributeTable(object):
 from jawa.attributes.code import CodeAttribute
 from jawa.attributes.source_file import SourceFileAttribute
 from jawa.attributes.constant_value import ConstantValueAttribute
+from jawa.attributes.signature import SignatureAttribute
 
 default_parsers = {
     'Code': CodeAttribute,
     'SourceFile': SourceFileAttribute,
-    'ConstantValue': ConstantValueAttribute
+    'ConstantValue': ConstantValueAttribute,
+    'Signature': SignatureAttribute
 }

--- a/jawa/attributes/signature.py
+++ b/jawa/attributes/signature.py
@@ -1,0 +1,28 @@
+# -*- coding: utf8 -*-
+from struct import unpack_from, pack
+from jawa.attribute import Attribute
+
+
+class SignatureAttribute(Attribute):
+    ADDED_IN = '5.0.0'
+    MINIMUM_CLASS_VERSION = (49, 0)
+
+    def __init__(self, table, signature=None, name_index=None):
+        super(SignatureAttribute, self).__init__(
+            table,
+            name_index or table.cf.constants.create_utf8(
+                'Signature'
+            ).index
+        )
+        self._signature_index = signature.index if signature else None
+
+    def unpack(self, info):
+        self._signature_index = unpack_from('>H', info)[0]
+
+    @property
+    def info(self):
+        return pack('>H', self._signature_index)
+
+    @property
+    def signature(self):
+        return self._cf.constants[self._signature_index]


### PR DESCRIPTION
This adds support for reading the Signature attribute ([jvms 4.7.9](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.9)).  It does not attempt to parse it, however, as the parsing rules ([jvms 4.7.9.1](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.9.1)) are rather complicated.