### PR TITLE
Fix misspelled 'ib2' (should be 'i2b') instruction

### DIFF
--- a/jawa/util/bytecode.py
+++ b/jawa/util/bytecode.py
@@ -201,7 +201,7 @@ opcode_table = {
     0xB2: ('getstatic', [(ushort, 30)]),
     0xA7: ('goto', [(short, 40)]),
     0xC8: ('goto_w', [(integer, 40)]),
-    0x91: ('ib2', None),
+    0x91: ('i2b', None),
     0x92: ('i2c', None),
     0x87: ('i2d', None),
     0x86: ('i2f', None),


### PR DESCRIPTION
Not sure if I should submit this to develop or master.  I found this while using burger on develop so that's the branch I made the change on, but it may make more sense on master.