### PR TITLE
Fix python 3 support

### DIFF
--- a/jawa/attributes/code.py
+++ b/jawa/attributes/code.py
@@ -3,7 +3,10 @@ from struct import pack
 from itertools import repeat
 from collections import namedtuple
 
-import six.moves
+try:
+    from cStringIO import StringIO as BytesIO
+except ImportError:
+    from io import BytesIO
 
 from jawa.attribute import Attribute, AttributeTable
 from jawa.util.bytecode import (
@@ -99,7 +102,7 @@ class CodeAttribute(Attribute):
         """
         The `CodeAttribute` in packed byte string form.
         """
-        fout = StringIO()
+        fout = BytesIO()
         fout.write(pack(
             '>HHI',
             self._max_stack,
@@ -152,7 +155,7 @@ class CodeAttribute(Attribute):
         Assembles an iterable of :class:`~jawa.util.bytecode.Instruction`
         objects into a method's code body.
         """
-        fout = six.moves.cStringIO()
+        fout = BytesIO()
         for ins in code:
             write_instruction(fout, fout.tell(), ins)
         self._code = fout.getvalue()
@@ -163,7 +166,7 @@ class CodeAttribute(Attribute):
         Disassembles this method, yielding an iterable of
         :class:`~jawa.util.bytecode.Instruction` objects.
         """
-        fio = six.moves.cStringIO(self._code)
+        fio = BytesIO(self._code)
 
         for ins in iter(lambda: read_instruction(fio, fio.tell()), None):
             yield ins

--- a/jawa/cf.py
+++ b/jawa/cf.py
@@ -190,8 +190,7 @@ class ClassFile(object):
 
     @version.setter
     def version(self, major_minor):
-        major, minor = major_minor
-        self._version = ClassVersion(major, minor)
+        self._version = ClassVersion(major_minor[0], major_minor[1])
 
     @property
     def constants(self):

--- a/jawa/cf.py
+++ b/jawa/cf.py
@@ -189,7 +189,8 @@ class ClassFile(object):
         return self._version
 
     @version.setter
-    def version(self, (major, minor)):
+    def version(self, major_minor):
+        major, minor = major_minor
         self._version = ClassVersion(major, minor)
 
     @property

--- a/jawa/util/classloader.py
+++ b/jawa/util/classloader.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 import os
 import os.path
-from itertools import izip, repeat
+from itertools import repeat
 from zipfile import ZipFile
 from collections import OrderedDict
 
+try:
+    from cStringIO import StringIO as BytesIO
+except ImportError:
+    from io import BytesIO
 import six
-import six.moves
 
 from jawa.cf import ClassFile
 
@@ -73,7 +76,7 @@ class ClassLoader(object):
             # get the index, and unpack it into our path map.
             if path.lower().endswith(('.zip', '.jar')):
                 zf = ZipFile(path, 'r')
-                self.path_map.update(izip(zf.namelist(), repeat(zf)))
+                self.path_map.update(six.zip(zf.namelist(), repeat(zf)))
             elif os.path.isdir(path):
                 walker = _walk(
                     path,
@@ -118,7 +121,7 @@ class ClassLoader(object):
                 # It's 2x as fast to read the entire file at once using
                 # read and wrapping it in a StringIO then it is to just
                 # ZipFile.open() it...
-                fio = six.moves.cStringIO(full_path.read(path))
+                fio = BytesIO(full_path.read(path))
                 try:
                     r = ClassFile(fio)
                 finally:

--- a/jawa/util/utf.py
+++ b/jawa/util/utf.py
@@ -8,6 +8,7 @@ when parsing and writing JVM ClassFiles or object serialization archives.
     for MUTF-8/CESU-8 into the python core.
 """
 
+import six
 
 def decode_modified_utf8(s):
     """
@@ -49,7 +50,7 @@ def decode_modified_utf8(s):
             ix += 1
             x = 0
         buffer_append(x)
-    return u''.join(map(unichr, buff))
+    return u''.join(map(six.unichr, buff))
 
 
 def encode_modified_utf8(u):

--- a/tests/test_sourcefile_attribute.py
+++ b/tests/test_sourcefile_attribute.py
@@ -3,9 +3,9 @@
 import os
 
 try:
-    from cStringIO import StringIO
+    from cStringIO import StringIO as BytesIO
 except ImportError:
-    from StringIO import StringIO
+    from io import BytesIO
 
 from jawa.cf import ClassFile
 from jawa.attributes.source_file import SourceFileAttribute
@@ -38,10 +38,10 @@ def test_sourcefile_write():
     sfa = cf_one.attributes.create(SourceFileAttribute)
     sfa.source_file = cf_one.constants.create_utf8(u'SourceFileTest.java')
 
-    fout = StringIO()
+    fout = BytesIO()
     cf_one.save(fout)
 
-    fin = StringIO(fout.getvalue())
+    fin = BytesIO(fout.getvalue())
     cf_two = ClassFile(fin)
 
     source_file = cf_two.attributes.find_one(name=u'SourceFile')


### PR DESCRIPTION
(Re?)adds python 3 compatibility.

The only complicated change here is that `StringIO` has been replaced with `BytesIO`.  While `six.moves.cStringIO` exists, it causes issues in the contexts it was used in (`TypeError: initial_value must be str or None, not bytes`).  `BytesIO` works in both python 2 and python 3; I've also used a `cStringIO` when available (I'm not actually sure whether `cStringIO` is faster than `BytesIO` in python 2, but I assume it is).

Tested against burger (with another set of changes there for python 3), so most reading stuff is covered but writing might not be.