### PR TITLE
More downstream stuff

### DIFF
--- a/lawu/ast.py
+++ b/lawu/ast.py
@@ -727,42 +727,7 @@ class EnclosingMethod(Attribute):
         )
 
 
-class BootstrapMethods(Attribute):
-    pass
-
-
-class Exceptions(Attribute):
-    pass
-
-
 class Deprecated(Attribute):
-    pass
-
-
-class InnerClasses(Attribute):
-    pass
-
-
-class LineNumberTable(Attribute):
-    __slots__ = ('entries',)
-
-    def __init__(self, *, entries, line_no=0, children=None):
-        super().__init__(line_no=line_no, children=children)
-        self.entries: Dict[int, int] = entries
-
-    def __eq__(self, other):
-        return (
-            isinstance(self, other.__class__) and
-            self.entries == other.entries and
-            self._re_eq(other)
-        )
-
-
-class LocalVariableTable(Attribute):
-    pass
-
-
-class LocalVariableTypeTable(Attribute):
     pass
 
 
@@ -802,4 +767,43 @@ class ConstantValue(ValueAttribute):
     pass
 
 class SourceFile(ValueAttribute):
+    pass
+
+
+class TableAttribute(Attribute):
+    __slots__ = ('entries',)
+
+    def __init__(self, *, entries, line_no=0, children=None):
+        super().__init__(line_no=line_no, children=children)
+        self.entries = entries
+
+    def __eq__(self, other):
+        return (
+            isinstance(self, other.__class__) and
+            self.entries == other.entries and
+            self._re_eq(other)
+        )
+
+
+class BootstrapMethods(TableAttribute):
+    pass
+
+
+class Exceptions(TableAttribute):
+    pass
+
+
+class InnerClasses(TableAttribute):
+    pass
+
+
+class LineNumberTable(TableAttribute):
+    pass
+
+
+class LocalVariableTable(TableAttribute):
+    pass
+
+
+class LocalVariableTypeTable(TableAttribute):
     pass

--- a/lawu/attributes/bootstrap.py
+++ b/lawu/attributes/bootstrap.py
@@ -10,9 +10,9 @@ from lawu.attribute import Attribute
 
 @dataclass
 class BootstrapMethod:
-    method_ref: MethodHandle
+    reference_kind: MethodHandle.ReferenceKind
+    reference_index: int
     args: Tuple[int]
-    parent: BootstrapMethods = None
 
 
 class BootstrapMethodsAttribute(Attribute):
@@ -21,11 +21,14 @@ class BootstrapMethodsAttribute(Attribute):
 
     @classmethod
     def from_binary(cls, pool: ConstantPool, source: BinaryIO) -> BootstrapMethods:
-        methods = []
+        entries = []
         for _ in repeat(None, unpack('>H', source.read(2))[0]):
             ref, arg_len = unpack('>HH', source.read(4))
-            methods.append(BootstrapMethod(
-                pool[ref], unpack(f'>{arg_len}H', source.read(arg_len * 2))
+            handle = pool[ref]
+            entries.append(BootstrapMethod(
+                handle.reference_kind,
+                handle.reference_index,
+                unpack(f'>{arg_len}H', source.read(arg_len * 2))
             ))
 
-        return BootstrapMethods(children=methods)
+        return BootstrapMethods(entries=entries)

--- a/lawu/attributes/exceptions.py
+++ b/lawu/attributes/exceptions.py
@@ -13,5 +13,5 @@ class ExceptionsAttribute(Attribute):
     @classmethod
     def from_binary(cls, pool: ConstantPool, source: BinaryIO) -> Exceptions:
         l = unpack('>H', source.read(2))[0]
-        exceptions = [pool[i].as_ast for i in unpack(f'>{l}H', source.read(l * 2))]
-        return Exceptions(children=exceptions)
+        entries = [pool[i] for i in unpack(f'>{l}H', source.read(l * 2))]
+        return Exceptions(entries=entries)

--- a/lawu/attributes/inner_classes.py
+++ b/lawu/attributes/inner_classes.py
@@ -27,7 +27,6 @@ class InnerClass:
     outer_class: Union[ConstantClass, None]
     inner_name: Union[UTF8, None]
     access_flags: AccessFlags
-    parent: InnerClasses = None
 
 
 class InnerClassesAttribute(Attribute):
@@ -36,15 +35,15 @@ class InnerClassesAttribute(Attribute):
 
     @classmethod
     def from_binary(cls, pool: ConstantPool, source: BinaryIO) -> InnerClasses:
-        inner_classes = []
+        entries = []
 
         for _ in repeat(None, unpack('>H', source.read(2))[0]):
             inner, outer, name, flags = unpack('>HHHH', source.read(8))
-            inner_classes.append(InnerClass(
+            entries.append(InnerClass(
                 pool[inner],
                 pool[outer] if outer else None,
                 pool[name] if name else None,
                 InnerClass.AccessFlags(flags)
             ))
 
-        return InnerClasses(children=inner_classes)
+        return InnerClasses(entries=entries)

--- a/lawu/attributes/local_variable.py
+++ b/lawu/attributes/local_variable.py
@@ -1,6 +1,5 @@
 from struct import unpack
 from typing import BinaryIO
-from itertools import repeat
 from dataclasses import dataclass
 
 from lawu.ast import LocalVariableTable
@@ -15,7 +14,6 @@ class LocalVariableEntry:
     name: UTF8
     descriptor: UTF8
     index: int
-    parent: LocalVariableTable = None
 
 
 class LocalVariableTableAttribute(Attribute):
@@ -24,10 +22,12 @@ class LocalVariableTableAttribute(Attribute):
 
     @classmethod
     def from_binary(cls, pool: ConstantPool, source: BinaryIO) -> LocalVariableTable:
-        local_variables = []
-        for _ in repeat(None, unpack('>H', source.read(2))[0]):
-            pc, length, name, desc, idx = unpack('>HHHHH', source.read(10))
-            local_variables.append(LocalVariableEntry(
+        entries = []
+        num_entries = unpack('>H', source.read(2))[0]
+        data = unpack(f'>{num_entries * 5}H', source.read(num_entries * 10))
+        for i in range(0, num_entries * 5, 5):
+            pc, length, name, desc, idx = data[i:i+5]
+            entries.append(LocalVariableEntry(
                 pc, length, pool[name], pool[desc], idx
             ))
-        return LocalVariableTable(children=local_variables)
+        return LocalVariableTable(entries=entries)

--- a/lawu/constants.py
+++ b/lawu/constants.py
@@ -1,6 +1,7 @@
 """
 Utilities for working with the ConstantPool found in JVM ClassFiles.
 """
+from enum import IntEnum
 from typing import Dict, Any, Deque, BinaryIO, Iterator, Union
 from collections import deque
 from struct import unpack, pack
@@ -350,9 +351,20 @@ class MethodHandle(Constant):
     __slots__ = ('reference_kind', 'reference_index')
     TAG = 15
 
+    class ReferenceKind(IntEnum):
+        REF_getField         = 1
+        REF_getStatic        = 2
+        REF_putField         = 3
+        REF_putStatic        = 4
+        REF_invokeVirtual    = 5
+        REF_invokeStatic     = 6
+        REF_invokeSpecial    = 7
+        REF_newInvokeSpecial = 8
+        REF_invokeInterface  = 9
+
     def __init__(self, *, pool=None, index=None):
         super().__init__(pool=pool, index=index)
-        self.reference_kind = None
+        self.reference_kind = self.ReferenceKind(1)
         self.reference_index = 0
 
     @property
@@ -363,10 +375,8 @@ class MethodHandle(Constant):
         return pack('>BH', self.reference_kind, self.reference_index)
 
     def unpack(self, source: BinaryIO):
-        self.reference_kind, self.reference_index = unpack(
-            '>BH',
-            source.read(3)
-        )
+        kind, self.reference_index = unpack('>BH', source.read(3))
+        self.reference_kind = self.ReferenceKind(kind)
 
     def __repr__(self):
         return (


### PR DESCRIPTION
This gets entries for all of the various table attributes out of the AST.

For `BootstrapMethods`, it unrolls the `MethodHandle` constant. Admittedly I don't understand this recommendation 100%, but I don't have a good reason _not_ to do it either. Constants are still rolled into all other attributes though, so let me know if I should be unrolling constants across the board. If that's the case we might want to look into a more universal `to_attr` method or something.

A `TableAttribute` base class is added

`ReferenceKind` is now an `IntEnum`